### PR TITLE
Ignore module still in use while deleting cache

### DIFF
--- a/test/res/ignore-module-still-in-use/a.js
+++ b/test/res/ignore-module-still-in-use/a.js
@@ -1,0 +1,1 @@
+require('./lib')

--- a/test/res/ignore-module-still-in-use/b.js
+++ b/test/res/ignore-module-still-in-use/b.js
@@ -1,0 +1,3 @@
+const {setState} = require('./lib')
+
+setState(3)

--- a/test/res/ignore-module-still-in-use/index.js
+++ b/test/res/ignore-module-still-in-use/index.js
@@ -1,0 +1,2 @@
+require('./a.js')
+require('./b.js')

--- a/test/res/ignore-module-still-in-use/lib.js
+++ b/test/res/ignore-module-still-in-use/lib.js
@@ -1,0 +1,10 @@
+const state = {}
+
+function setState(num) {
+    state.a = num
+}
+
+module.exports = {
+    state,
+    setState
+}

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -94,13 +94,13 @@ it('nonexistent root module', () => {
     expect(() => {
         require('chalk')
         delcache('chalk', 1, '../../nonexistent')
-    }).to.not.throw()
+    }).to.throw()
 })
 
 it('root module', function () {
     require('./res/seven')
     module.parent.children.push(require.cache[require.resolve('./res/seven')])
-    delcache('./res/seven', 1, module)
+    delcache('./res/seven', 1, module.filename)
     const count = module.parent.children.filter(m => {
         return m.id == require.resolve('./res/seven')
     }).length

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -106,3 +106,10 @@ it('root module', function () {
     }).length
     expect(count).to.be.equal(1)
 })
+
+it('ignore module that is still in use', function () {
+    require('./res/ignore-module-still-in-use/index')
+    expect(require('./res/ignore-module-still-in-use/lib').state.a).to.be.equal(3);
+    delcache('./res/ignore-module-still-in-use/a', true, './res/ignore-module-still-in-use/index')
+    expect(require('./res/ignore-module-still-in-use/lib').state.a).to.be.equal(3);
+})


### PR DESCRIPTION
Find all files that still accessible from root path after deleting cache, ignore them.

see case in `test/res/ignore-module-still-in-use`